### PR TITLE
[Refactor] #27 공통버튼 컴포넌트 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,16 +1,57 @@
+"use client";
 import React from "react";
+import { clsx } from "clsx";
+import { ButtonProps } from "@/types/common";
 
-interface CommonButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
-  className?: string;
-}
+const colorMap = {
+  primary: {
+    fill: "bg-primary text-white hover:bg-primary-light active:bg-primary-deep",
+    outline:
+      "bg-transparent border border-2 border-primary text-primary-deep hover:bg-transparent active:text-white active:bg-primary-deep",
+  },
+  gray: {
+    fill: "bg-gray-500 text-white hover:bg-gray-600 active:bg-gray-700",
+    outline:
+      "bg-transparent border border-2 border-gray-500 text-gray-600 hover:bg-transparent active:text-white active:bg-gray-700",
+  },
+  accent: {
+    fill: "bg-accent-main text-white hover:opacity-80 active:opacity-100",
+    outline:
+      "bg-transparent border border-2 border-accent-main text-accent-main hover:bg-transparent active:text-white active:bg-accent-main",
+  },
+  red: {
+    fill: "bg-accent-red text-white hover:bg-red-600 active:bg-red-700",
+    outline:
+      "bg-transparent border border-red-500 text-red-500 hover:bg-transparent active:bg-red-600",
+  },
+};
 
-const CommonButton = ({ children, className = "", ...props }: CommonButtonProps) => {
+const Button = ({
+  className = "",
+  color = "primary",
+  variant = "fill",
+  width = "w-[160px]",
+  height = "h-[48px]",
+  children,
+  onClick,
+  type = "button",
+  ...props
+}: ButtonProps) => {
+  const baseStyle =
+    "rounded-md font-medium flex justify-center items-center text-md px-4";
+  const variantStyle = colorMap[color][variant];
+  const sizeStyle = `${width} ${height}`;
+
   return (
-    <button className={className} {...props}>
+    <button
+      className={clsx(baseStyle, variantStyle, sizeStyle, className)}
+      onClick={onClick}
+      type={type}
+      {...props}
+    >
       {children}
     </button>
   );
 };
 
-export default CommonButton;
+export default Button;

--- a/src/components/common/CommonButton.tsx
+++ b/src/components/common/CommonButton.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface CommonButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const CommonButton = ({ children, className = "", ...props }: CommonButtonProps) => {
+  return (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default CommonButton;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,13 +1,12 @@
-import { MouseEventHandler } from "react";
-
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLInputElement> {
-  title: string;
-  rightIcon?: string;
-  handleClick?: MouseEventHandler<HTMLButtonElement>;
-  btnType?: "button" | "submit";
-  isDisabled?: boolean;
+export interface ButtonProps{
   className: string;
+  color?: "primary" | "gray" | "accent" | "red";
+  variant?: "fill" | "outline"; 
+  width?: string;
+  height?: string;
+  onClick?: () => void;
+  type?: "button" | "submit";
+  children: React.ReactNode;
 }
 
 export interface InputProps
@@ -37,7 +36,7 @@ export interface CommonInputProps {
 }
 
 export interface IconButtonProps {
-    onClick: () => void;
-    size: number;
-    className?: string;
+  onClick: () => void;
+  size: number;
+  className?: string;
 }


### PR DESCRIPTION
## 변경 사항
공통 버튼 컴포넌트 속성 추가

## 반영 브랜치
refactor/#27-common-button -> develop

## 관련 이슈
close #27 

## 참고 사항
* props 항목 추가
    * className: string;
    * color?: "primary" | "gray" | "accent" | "red";
    * variant?: "fill" | "outline"; 
    * width?: string;
    * height?: string;
    * onClick?: () => void;
    * type?: "button" | "submit";
    * children: React.ReactNode;