### PR TITLE
[Feature]#21 signup 임시 UI 구현

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+import { useSignupStore } from "@/stores/useSignUpStore";
+import TextInput from "@/components/common/TextInput";
+import AreaSelector from "@/components/common/AreaSelector";
+import InterestSelector from "@/components/InterestSelector";
+import DigitalLevelSelector from "@/components/DigitalLevelSelector";
+import { useSignupSubmit } from "@/hooks/useSignupSubmit";
+
+export default function SignupPage() {
+  const { handleSubmit, setValue } = useSignupSubmit();
+  const {
+    email,
+    password,
+    password_confirm,
+    nickname,
+    name,
+    phone,
+    birthYear,
+    birthMonth,
+    birthDay,
+    agreement,
+    toggleAgreement,
+  } = useSignupStore();
+
+  return (
+    <main className="w-full max-w-[1280px] px-16 py-12 mx-auto">
+      <h1 className="text-xl font-bold mb-10">회원가입</h1>
+
+      <div className="w-full flex justify-center mt-20">
+        <form
+          id="signupForm"
+          onSubmit={handleSubmit}
+          className="space-y-6 w-full max-w-md"
+        >
+          <div>
+            <label className="text-xs font-bold text-gray-700">이름</label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="이름"
+                name="name"
+                value={name}
+                onChange={(e) => setValue("name", e.target.value)}
+                required
+                type="text"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-bold text-gray-700">닉네임</label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="닉네임"
+                name="nickname"
+                value={nickname}
+                onChange={(e) => setValue("nickname", e.target.value)}
+                required
+                type="text"
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="birthYear"
+              className="text-xs font-bold text-gray-700"
+            >
+              생년월일
+            </label>
+            <div className="mt-3 flex gap-2 items-center">
+              <TextInput
+                name="birthYear"
+                value={birthYear}
+                onChange={(e) => setValue("birthYear", e.target.value)}
+                placeholder="YYYY"
+                type="number"
+                required
+              />
+              <span className=" text-gray-400">/</span>
+              <TextInput
+                name="birthMonth"
+                value={birthMonth}
+                onChange={(e) => setValue("birthMonth", e.target.value)}
+                placeholder="MM"
+                type="number"
+                required
+              />
+              <span className="text-gray-400">/</span>
+              <TextInput
+                name="birthDay"
+                value={birthDay}
+                onChange={(e) => setValue("birthDay", e.target.value)}
+                placeholder="DD"
+                type="number"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs font-bold text-gray-700">이메일</label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="이메일"
+                name="email"
+                value={email}
+                onChange={(e) => setValue("email", e.target.value)}
+                required
+                type="email"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-bold text-gray-700">비밀번호</label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="비밀번호"
+                name="password"
+                value={password}
+                onChange={(e) => setValue("password", e.target.value)}
+                required
+                type="password"
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="birthYear"
+              className="text-xs font-bold text-gray-700"
+            >
+              비밀번호 확인
+            </label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="비밀번호 확인"
+                name="password_confirm"
+                value={password_confirm}
+                onChange={(e) => setValue("password_confirm", e.target.value)}
+                required
+                type="password"
+              />
+            </div>
+          </div>
+
+          {/* <div className="-mx-16 border-t border-gray-500 my-12" /> */}
+          <div>
+            <label className="text-xs font-bold text-gray-700">전화번호</label>
+            <div className="mt-3">
+              <TextInput
+                placeholder="전화번호"
+                name="phone"
+                value={phone}
+                onChange={(e) => setValue("phone", e.target.value)}
+                required
+                type="text"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-bold text-gray-700">지역</label>
+            <div className="mt-3">
+              <AreaSelector />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs font-bold text-gray-700">
+              관심사(중복가능)
+            </label>
+            <div className="mt-3">
+              <InterestSelector />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs font-bold text-gray-700">
+              디지털 친숙도
+            </label>
+            <div className="mt-3">
+              <DigitalLevelSelector />
+            </div>
+          </div>
+          {/* 약관 동의 & 완료 버튼 */}
+          <div className="mt-12 border-t border-gray-300 pt-8 space-y-4">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={agreement}
+                onChange={toggleAgreement}
+                className="accent-orange-600 w-4 h-4"
+                id="agreement"
+              />
+              <label
+                htmlFor="agreement"
+                className="leading-snug break-words text-gray-700"
+              >
+                [필수] ‘개인정보 수집 및 이용’, ‘서비스 이용 약관’ 등에 모두
+                동의합니다.
+              </label>
+            </div>
+
+            <button
+              type="submit"
+              form="signupForm"
+              className="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 rounded"
+            >
+              완료하기
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/components/DigitalLevelSelector.tsx
+++ b/src/components/DigitalLevelSelector.tsx
@@ -1,0 +1,32 @@
+import { useSignupStore } from "@/stores/useSignUpStore";
+
+const DIGITAL_LEVELS = [
+  { id: 1, label: "상 - zoom 화상 회의 가능" },
+  { id: 2, label: "중 - 기본적인 앱 사용 가능" },
+  { id: 3, label: "하 - 전화만 가능" },
+];
+
+export default function DigitalLevelSelector() {
+  const { digitalLevel_id, setValue } = useSignupStore();
+
+  return (
+    <div>
+      {DIGITAL_LEVELS.map((level) => (
+        <label key={level.id} className="flex items-center gap-2 text-gray-800">
+          <input
+            type="radio"
+            className="accent-orange-600"
+            checked={digitalLevel_id === level.id}
+            onChange={() =>
+              setValue(
+                "digitalLevel_id",
+                digitalLevel_id === level.id ? null : level.id
+              )
+            }
+          />
+          {level.label}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/InterestSelector.tsx
+++ b/src/components/InterestSelector.tsx
@@ -1,0 +1,34 @@
+import { useSignupStore } from "@/stores/useSignUpStore";
+
+const INTERESTS = [
+  "여행(지역탐방)",
+  "건강관리/운동",
+  "문화예술/창작",
+  "요리/음식",
+  "자기계발",
+  "봉사/재능기부",
+  "명상(마음챙김)",
+  "디지털 학습",
+  "사교/친목도모",
+  "기타",
+] as const;
+
+export default function InterestSelector() {
+  const { selectedInterests, toggleInterest } = useSignupStore();
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {INTERESTS.map((interest) => (
+        <label key={interest} className="flex items-center gap-2 text-gray-800">
+          <input
+            type="checkbox"
+            className="accent-orange-600"
+            checked={selectedInterests.includes(interest)}
+            onChange={() => toggleInterest(interest)}
+          />
+          {interest}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/common/AreaSelector.tsx
+++ b/src/components/common/AreaSelector.tsx
@@ -1,0 +1,102 @@
+import { useSignupStore } from "@/stores/useSignUpStore";
+
+export default function AreaSelector() {
+  const AREA_OPTIONS = {
+    서울: [
+      "강남구",
+      "강동구",
+      "강북구",
+      "강서구",
+      "광진구",
+      "관악구",
+      "송파구",
+    ],
+    부산: ["해운대구", "수영구", "부산진구"],
+    대구: ["수성구", "중구", "달서구"],
+    인천: ["중구", "남동구", "부평구"],
+    광주: ["동구", "서구", "광산구"],
+    대전: ["동구", "중구", "유성구"],
+  } as const;
+
+  type Sido = keyof typeof AREA_OPTIONS;
+
+  const { selectedSido, selectedDistricts, selectSido, toggleDistrict } =
+    useSignupStore();
+
+  const sidos = Object.keys(AREA_OPTIONS) as Sido[];
+  const districts = selectedSido ? AREA_OPTIONS[selectedSido as Sido] : [];
+
+  return (
+    <div className="w-full max-w-[600px] border rounded-lg p-4 bg-white h-[300px]">
+      <div className="grid grid-cols-2 gap-4 h-full">
+        {/* 지역 */}
+        <div className="flex flex-col gap-2 h-full">
+          <div className="font-semibold sticky top-0 bg-white px-3 py-2 pb-1">
+            전국
+          </div>
+          <div className="overflow-auto" style={{ maxHeight: "230px" }}>
+            {sidos.map((sido) => (
+              <button
+                key={sido}
+                type="button"
+                onClick={() => selectSido(sido)}
+                className={`w-full text-left px-3 py-2 rounded ${
+                  selectedSido === sido
+                    ? "border-orange-500 bg-orange-100 font-bold text-orange-600"
+                    : "bg-white hover:bg-gray-100"
+                }`}
+              >
+                {sido}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 오른쪽: 구/군 체크박스 */}
+        <div className="flex flex-col gap-2 h-full">
+          <label className="sticky top-0 bg-white px-2 py-1 flex items-center justify-between ">
+            <span className="font-semibold">전체</span>
+            <input
+              type="checkbox"
+              checked={districts.every((d) => selectedDistricts.includes(d))}
+              onChange={() => {
+                // 전체 선택/해제 토글
+                if (districts.every((d) => selectedDistricts.includes(d))) {
+                  districts.forEach((d) => toggleDistrict(d)); // 해제
+                } else {
+                  districts
+                    .filter((d) => !selectedDistricts.includes(d))
+                    .forEach((d) => toggleDistrict(d)); // 선택
+                }
+              }}
+              className="accent-orange-600 w-4 h-4"
+            />
+          </label>
+          <div
+            className="overflow-y-auto flex-1"
+            style={{ maxHeight: "230px" }}
+          >
+            {districts.map((district: string) => (
+              <label
+                key={district}
+                className="flex items-center justify-between px-2 py-1 h-10 text-gray-700"
+              >
+                <span
+                  className={`${selectedDistricts.includes(district) ? "font-bold" : ""}`}
+                >
+                  {district}
+                </span>
+                <input
+                  type="checkbox"
+                  checked={selectedDistricts.includes(district)}
+                  onChange={() => toggleDistrict(district)}
+                  className="accent-orange-600 w-4 h-4"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -1,11 +1,23 @@
 import React from "react";
 import { CommonInputProps } from "@/types/common";
 
-const TextInput = ({ label, name, value, onChange, placeholder, required }: CommonInputProps) => (
+const TextInput = ({
+  type,
+  label,
+  name,
+  value,
+  onChange,
+  placeholder,
+  required,
+}: CommonInputProps) => (
   <div className="flex flex-col gap-1 font-sans text-main">
-    {label && <label htmlFor={name} className="text-sm font-medium text-gray-700">{label}</label>}
+    {label && (
+      <label htmlFor={name} className="text-sm font-medium text-gray-700">
+        {label}
+      </label>
+    )}
     <input
-      type="text"
+      type={type}
       id={name}
       name={name}
       value={value}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="fixed bottom-0 left-0 w-full bg-white h-[160px] border-t border-gray-500 z-50">
+    <footer className="bottom-0 left-0 w-full bg-white h-[160px] border-t border-gray-500 z-50">
       <div className="mx-auto flex h-full items-center justify-between px-12 font-[10px] text-gray-500">
         <div className="flex items-center gap-10">
           <Link href={"/"}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
       {/* 우측 */}
       <div className="flex gap-6 text-black font-medium text-base">
         <Link href={"#"}>로그인</Link>
-        <Link href={"#"}>마이페이지</Link>
+        <Link href={"/signup"}>회원가입</Link>
       </div>
     </div>
   );

--- a/src/hooks/useSignupSubmit.ts
+++ b/src/hooks/useSignupSubmit.ts
@@ -1,0 +1,73 @@
+"use client";
+import { useSignupStore } from "@/stores/useSignUpStore";
+import { useRouter } from "next/navigation";
+
+export function useSignupSubmit() {
+  const router = useRouter();
+
+  const {
+    email,
+    password,
+    password_confirm,
+    name,
+    phone,
+    birthYear,
+    birthMonth,
+    setValue,
+    agreement,
+    resetForm,
+  } = useSignupStore();
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const requiredFields = [
+      { key: "name", value: name },
+      { key: "birthYear", value: birthYear },
+      { key: "birthMonth", value: birthMonth },
+      { key: "email", value: email },
+      { key: "password", value: password },
+      { key: "password_confirm", value: password_confirm },
+      { key: "phone", value: phone },
+    ];
+
+    const firstEmpty = requiredFields.find((field) => !field.value?.trim());
+
+    if (firstEmpty) {
+      const target = document.querySelector(
+        `input[name="${firstEmpty.key}"]`
+      ) as HTMLElement;
+      alert("모든 필드를 입력해주세요.");
+      target?.focus();
+      return;
+    }
+
+    if (password !== password_confirm) {
+      alert("비밀번호가 일치하지 않습니다.");
+      const passwordConfirmInput = document.querySelector(
+        `input[name="password_confirm"]`
+      ) as HTMLElement;
+      passwordConfirmInput?.focus();
+      return;
+    }
+
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+    if (!passwordRegex.test(password)) {
+      alert("비밀번호는 영문+숫자 조합의 8자 이상이어야 합니다.");
+      const passwordInput = document.querySelector(
+        `input[name="password"]`
+      ) as HTMLElement;
+      passwordInput?.focus();
+      return;
+    }
+
+    if (!agreement) {
+      alert("약관에 동의해주세요.");
+      const checkbox = document.getElementById("agreement");
+      checkbox?.focus();
+      return;
+    }
+    resetForm();
+    router.push("/");
+  };
+  return { handleSubmit, setValue };
+}

--- a/src/stores/useSignUpStore.ts
+++ b/src/stores/useSignUpStore.ts
@@ -1,0 +1,109 @@
+import { create } from "zustand";
+
+interface SignupState {
+  email: string;
+  password: string;
+  password_confirm: string;
+  nickname: string;
+  name: string;
+  phone: string;
+  area_id: number | null;
+  interest_id: number | null;
+  digitalLevel_id: number | null;
+  birthYear: string;
+  birthMonth: string;
+  birthDay: string;
+
+  // 지역
+  selectedSido: string; // 현재 선택된 시/도
+  selectedDistricts: string[];
+
+  // 관심사
+  selectedInterests: string[];
+  toggleInterest: (interest: string) => void;
+
+  // 약관 동의
+  agreement: boolean;
+  toggleAgreement: () => void;
+
+  // 공통 상태 업데이트 함수
+  setValue: <T extends keyof SignupState>(
+    key: T,
+    value: SignupState[T]
+  ) => void;
+
+  // 구/군
+  toggleDistrict: (district: string) => void;
+  // 시/도
+  selectSido: (sido: string) => void;
+  resetForm: () => void;
+}
+
+export const useSignupStore = create<SignupState>((set) => ({
+  // 초기 값
+  email: "",
+  password: "",
+  password_confirm: "",
+  nickname: "",
+  name: "",
+  phone: "",
+  area_id: null,
+  interest_id: null,
+  digitalLevel_id: null,
+  birthYear: "",
+  birthMonth: "",
+  birthDay: "",
+
+  selectedSido: "서울",
+  selectedDistricts: [],
+  selectedInterests: [],
+  agreement: false,
+
+  // 관심사 토글함수
+  toggleInterest: (interest: string) =>
+    set((state) => ({
+      selectedInterests: state.selectedInterests.includes(interest)
+        ? state.selectedInterests.filter((i) => i !== interest)
+        : [...state.selectedInterests, interest],
+    })),
+
+  setValue: (key, value) => set((state) => ({ ...state, [key]: value })),
+
+  // 구/군 토글함수
+  toggleDistrict: (district) =>
+    set((state) => ({
+      selectedDistricts: state.selectedDistricts.includes(district)
+        ? state.selectedDistricts.filter((d) => d !== district)
+        : [...state.selectedDistricts, district],
+    })),
+
+  // 시/도 데이터를 바꾸는 함수
+  selectSido: (sido) =>
+    set(() => ({
+      selectedSido: sido,
+      selectedDistricts: [], // 사용자가 선택한 지역을 담고 있는 배열 상태
+    })),
+
+  toggleAgreement: () => set((state) => ({ agreement: !state.agreement })),
+
+  // 폼상태 초기화
+  resetForm: () =>
+    set({
+      email: "",
+      password: "",
+      password_confirm: "",
+      nickname: "",
+      name: "",
+      phone: "",
+      area_id: null,
+      interest_id: null,
+      digitalLevel_id: null,
+      birthYear: "",
+      birthMonth: "",
+      birthDay: "",
+      selectedSido: "서울",
+      selectedDistricts: [],
+      selectedInterests: [],
+      agreement: false,
+    }),
+}));

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -34,10 +34,11 @@ export interface CommonInputProps {
   ) => void;
   placeholder?: string;
   required?: boolean;
+  type?: "text" | "email" | "password" | "number";
 }
 
 export interface IconButtonProps {
-    onClick: () => void;
-    size: number;
-    className?: string;
+  onClick: () => void;
+  size: number;
+  className?: string;
 }


### PR DESCRIPTION
## 변경 사항  
회원가입 페이지 UI를 구현했습니다.  
- 이름, 생년월일, 이메일, 비밀번호, 전화번호 입력 폼  
- 지역 선택 (시/도, 구/군) 기능  
- 관심사 다중 선택 기능  
- 디지털 친숙도 단일 선택 기능  
- 약관 동의 체크박스 및 완료하기 버튼  
- 입력값 검증 및 에러 처리 (필수 입력, 비밀번호 조건 등)  
- 완료 시 홈으로 이동 및 상태 초기화

## 반영 브랜치  
feature/#21-signup_ui -> develop

## 관련 이슈  
close #21

## 참고 사항  
- `Zustand`를 사용하여 상태 관리했습니다.  
- 페이지 이동은 `next/navigation`의 `useRouter`를 활용했습니다.  
- 잘못된 입력 시 포커스 이동 및 alert 표시로 UX 개선
