### PR TITLE
[Design] #64 헤더 반응형 구현

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useAuthStore } from "@/stores/useAuth";
@@ -9,6 +9,8 @@ import { useRouter } from "next/navigation";
 export default function Header() {
   const { currentUser, logout } = useAuthStore();
   const { isKakaoUserSignedUp, setKakaoUserSignedUp } = useSignupStore();
+  const [isMobile, setIsMobile] = useState(false);
+
   const router = useRouter();
   const handleLogout = () => {
     logout();
@@ -16,8 +18,10 @@ export default function Header() {
     router.push("/");
   };
 
+  const toggleMenu = () => setIsMobile((prev) => !prev);
+
   return (
-    <div className="w-full h-[110px] flex items-center justify-between px-12">
+    <div className="w-full h-[110px] flex items-center justify-between md:px-12 px-6 relative z-50">
       {/* 로고 부분*/}
       <div className="flex items-center">
         <Link href="/">
@@ -26,7 +30,7 @@ export default function Header() {
       </div>
 
       {/* 중앙 */}
-      <nav className="flex gap-10 text-black font-medium text-base">
+      <nav className="hidden md:flex gap-10 text-black font-medium text-base">
         <Link href={"/"}>홈으로</Link>
         <Link href={"/meet/search"}>모임찾기</Link>
         <Link href={"#"}>리더신청</Link>
@@ -35,7 +39,7 @@ export default function Header() {
       </nav>
 
       {/* 우측 */}
-      <div className="flex gap-6 text-black font-medium text-base">
+      <div className="hidden md:flex gap-6 text-black font-medium text-base">
         {currentUser || isKakaoUserSignedUp ? (
           <>
             <button onClick={handleLogout} className="hover:underline">
@@ -50,6 +54,51 @@ export default function Header() {
           </>
         )}
       </div>
+
+      {/* 햄버거 버튼 - 모바일 */}
+      <button onClick={toggleMenu} className="md:hidden">
+        <svg className="w-8 h-8" fill="none" stroke="black" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d={isMobile ? "M6 18L18 6M6 6l12 12" : "M4 6h16M4 12h16M4 18h16"}
+          />
+        </svg>
+      </button>
+      {isMobile && (
+        <div className="absolute top-[110px] left-0 w-full shadow-md px-6 py-4 flex flex-col gap-4 md:hidden bg-white text-black text-base">
+          <Link href={"/"}>홈으로</Link>
+          <Link href={"/meet/search"}>모임찾기</Link>
+          <Link href={"#"}>리더신청</Link>
+          <Link href={"/community"}>소통하기</Link>
+          <Link href={"/about"}>온:다 소개</Link>
+          {currentUser || isKakaoUserSignedUp ? (
+            <div className="flex justify-end gap-4 mt-6 text-black text-base font-medium">
+              <Link href="/mypage" onClick={toggleMenu}>
+                마이페이지
+              </Link>
+              <button
+                onClick={() => {
+                  handleLogout();
+                  toggleMenu();
+                }}
+              >
+                로그아웃
+              </button>
+            </div>
+          ) : (
+            <div className="flex justify-end gap-4 text-base text-black font-medium">
+              <Link href="/login" onClick={toggleMenu}>
+                로그인
+              </Link>
+              <Link href="/signup" onClick={toggleMenu}>
+                회원가입
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 변경 사항
헤더 반응형 UI 구현
<img width="502" alt="image" src="https://github.com/user-attachments/assets/6067c918-7e34-4eff-a588-677bc47dec9d" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/afd5dff5-84d9-44ea-ac0c-1d3d9efa4aae" />


## 반영 브랜치
design/#64-header_mobile_ui -> develop

## 관련 이슈
close #64

## 참고 사항
추가로 공유하고 싶은 내용
