### PR TITLE
[Feature] #112 마이페이지 개인 프로필 api 연결

### DIFF
--- a/src/app/mypage/_components/UserProfile.tsx
+++ b/src/app/mypage/_components/UserProfile.tsx
@@ -1,19 +1,61 @@
-'use client';
+"use client";
 
-import { sampleUser } from '@/datas/sampleUser';
-import { ArrowLeftRight, Camera, SquarePen, UserRound } from 'lucide-react';
-import Image from 'next/image';
-import { useViewModeStore } from '@/stores/useViewModeStore';
+// import { sampleUser } from "@/datas/sampleUser";
+import { ArrowLeftRight, Camera, SquarePen, UserRound } from "lucide-react";
+import Image from "next/image";
+import { useViewModeStore } from "@/stores/useViewModeStore";
+import { useAuthStore } from "@/stores/useAuth";
+import { useEffect, useState } from "react";
+import api from "@/apis/app";
+import { END_POINT } from "@/constants/route";
+
+interface Profile {
+  email: string;
+  name: string;
+  nickname: string;
+  phone_number?: string;
+  date_of_birth?: string;
+  digital_level?: {
+    display: string;
+  };
+  interests?: {
+    interest_name: string;
+  }[];
+  file?: string;
+}
 
 const UserProfile = () => {
-  const user = sampleUser;
   const { viewMode, toggleViewMode } = useViewModeStore();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const role = useAuthStore((s) => s.user?.role);
+  const isAdmin = role === "admin";
+  const isLeader = role === "leader";
+
+  console.log(accessToken);
+  console.log("profile: ", profile);
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await api.get(END_POINT.USERS_PROFILE, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        console.log("res", res.data);
+        setProfile(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchProfile();
+  }, [accessToken]);
 
   return (
     <div className="space-y-4">
       {/* 상단 이름 + 수정 버튼 */}
       <div className="flex items-center">
-        <h3 className="text-lg font-semibold">{user.name}님</h3>
+        <h3 className="text-lg font-semibold">{profile?.name}님</h3>
         <button className="text-gray-500 hover:text-black ml-3">
           <SquarePen />
         </button>
@@ -23,9 +65,9 @@ const UserProfile = () => {
       <div className="flex items-center space-x-6">
         <div className="relative w-52 h-52">
           <div className="w-52 h-52 rounded-full overflow-hidden border bg-gray-100 flex items-center justify-center">
-            {user.imageUrl ? (
+            {profile?.file ? (
               <Image
-                src={user.imageUrl}
+                src={profile?.file}
                 alt="프로필 이미지"
                 fill
                 className="object-cover"
@@ -45,37 +87,39 @@ const UserProfile = () => {
         <div className="flex flex-col space-y-3 text-sm text-gray-800">
           <p>
             <span className="font-semibold mr-2">이메일</span>
-            {user.email}
+            {profile?.email}
           </p>
           <p>
             <span className="font-semibold mr-2">전화번호</span>
-            {user.phone}
+            {profile?.phone_number ?? "-"}
           </p>
           <p>
             <span className="font-semibold mr-2">생년월일</span>
-            {user.birth.toLocaleDateString('ko-KR')}
+            {profile?.date_of_birth
+              ? new Date(profile.date_of_birth).toLocaleDateString("ko-KR")
+              : "-"}
           </p>
-          {user.isAdmin || user.isLeader ? (
+          {isAdmin || isLeader ? (
             <p>
               <span className="font-semibold mr-2">디지털난이도</span>
-              {user.digitalLevel}
+              {profile?.digital_level?.display ?? "-"}
             </p>
           ) : (
             <p>
               <span className="font-semibold mr-2">관심 분야</span>
-              {user.interest.join(', ')}
+              {profile?.interests?.map((i) => i.interest_name).join(", ")}
             </p>
           )}
         </div>
 
         {/* 사용자 변경 버튼 */}
-        {user.isLeader && (
+        {isLeader && (
           <button
             onClick={toggleViewMode}
             className="flex items-center ml-auto px-3 py-1 border rounded-full text-xs text-gray-600 hover:bg-gray-100"
           >
             <ArrowLeftRight size={16} className="mr-1" />
-            {viewMode === 'leader' ? '일반 유저로 전환' : '리더 유저로 전환'}
+            {viewMode === "leader" ? "일반 유저로 전환" : "리더 유저로 전환"}
           </button>
         )}
       </div>


### PR DESCRIPTION
## 변경 사항
- 마이페이지에서 유저 프로필 데이터를 불러오는 API 연동 로직 추가
- Zustand에서 accessToken 전역 상태를 활용해 /api/users/profile 호출
- 응답받은 프로필 정보를 UserProfile 컴포넌트에 바인딩 (이름, 이메일, 전화번호, 생년월일, 관심사 등)
- 관리자/리더 권한 조건부 렌더링을 위한 전역 user.role 활용

[일반 회원]
<img width="827" alt="image" src="https://github.com/user-attachments/assets/aa51bb24-cabc-4e48-9f27-9f823c5b8b95" />
[리더 & 관리자]
<img width="667" alt="image" src="https://github.com/user-attachments/assets/80db93fa-15ba-46ff-b79d-eb051da69742" />


## 반영 브랜치
feature/#112-profile_api -> develop

## 관련 이슈
close #112 

## 참고 사항
추가로 공유하고 싶은 내용
