### PR TITLE
[Feature] #116 profile수정페이지 구현

### DIFF
--- a/src/app/mypage/_components/UserProfile.tsx
+++ b/src/app/mypage/_components/UserProfile.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-// import { sampleUser } from "@/datas/sampleUser";
 import { ArrowLeftRight, Camera, SquarePen, UserRound } from "lucide-react";
 import Image from "next/image";
 import { useViewModeStore } from "@/stores/useViewModeStore";
@@ -8,8 +7,9 @@ import { useAuthStore } from "@/stores/useAuth";
 import { useEffect, useState } from "react";
 import api from "@/apis/app";
 import { END_POINT } from "@/constants/route";
+import { useRouter } from "next/navigation";
 
-interface Profile {
+export interface Profile {
   email: string;
   name: string;
   nickname: string;
@@ -25,11 +25,12 @@ interface Profile {
 }
 
 const UserProfile = () => {
+  const route = useRouter();
   const { viewMode, toggleViewMode } = useViewModeStore();
   const [profile, setProfile] = useState<Profile | null>(null);
   const accessToken = useAuthStore((state) => state.accessToken);
   const role = useAuthStore((s) => s.user?.role);
-  const isAdmin = role === "admin";
+  // const isAdmin = role === "admin";
   const isLeader = role === "leader";
 
   console.log(accessToken);
@@ -56,18 +57,23 @@ const UserProfile = () => {
       {/* 상단 이름 + 수정 버튼 */}
       <div className="flex items-center">
         <h3 className="text-lg font-semibold">{profile?.name}님</h3>
-        <button className="text-gray-500 hover:text-black ml-3">
+        <button
+          className="text-gray-500 hover:text-black ml-3"
+          onClick={() => route.push("/mypage/edit_profile")}
+          aria-label="프로필 수정"
+        >
           <SquarePen />
         </button>
       </div>
 
       {/* 프로필 영역 */}
       <div className="flex items-center space-x-6">
+        {/* 이미지 */}
         <div className="relative w-52 h-52">
           <div className="w-52 h-52 rounded-full overflow-hidden border bg-gray-100 flex items-center justify-center">
             {profile?.file ? (
               <Image
-                src={profile?.file}
+                src={profile.file}
                 alt="프로필 이미지"
                 fill
                 className="object-cover"
@@ -83,7 +89,7 @@ const UserProfile = () => {
           </div>
         </div>
 
-        {/* 유저 정보 */}
+        {/* 정보 */}
         <div className="flex flex-col space-y-3 text-sm text-gray-800">
           <p>
             <span className="font-semibold mr-2">이메일</span>
@@ -99,20 +105,18 @@ const UserProfile = () => {
               ? new Date(profile.date_of_birth).toLocaleDateString("ko-KR")
               : "-"}
           </p>
-          {isAdmin || isLeader ? (
-            <p>
-              <span className="font-semibold mr-2">디지털난이도</span>
-              {profile?.digital_level?.display ?? "-"}
-            </p>
-          ) : (
-            <p>
-              <span className="font-semibold mr-2">관심 분야</span>
-              {profile?.interests?.map((i) => i.interest_name).join(", ")}
-            </p>
-          )}
+          <p>
+            <span className="font-semibold mr-2">디지털난이도</span>
+            {profile?.digital_level?.display ?? "-"}
+          </p>
+
+          <p>
+            <span className="font-semibold mr-2">관심 분야</span>
+            {profile?.interests?.map((i) => i.interest_name).join(", ")}
+          </p>
         </div>
 
-        {/* 사용자 변경 버튼 */}
+        {/* 보기 모드 전환 버튼 */}
         {isLeader && (
           <button
             onClick={toggleViewMode}

--- a/src/app/mypage/edit_profile/page.tsx
+++ b/src/app/mypage/edit_profile/page.tsx
@@ -222,6 +222,15 @@ export default function EditProfilePage() {
         >
           수정 완료
         </button>
+        <div className="flex gap-4 mt-4">
+          <button
+            type="button"
+            onClick={() => router.replace("/mypage")}
+            className="w-full bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-3 rounded"
+          >
+            수정 취소
+          </button>
+        </div>
       </form>
     </main>
   );

--- a/src/app/mypage/edit_profile/page.tsx
+++ b/src/app/mypage/edit_profile/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import AreaSelector from "@/components/common/AreaSelector";
+import InterestSelector from "@/app/signup/_components/InterestSelector";
+import DigitalLevelSelector from "@/app/signup/_components/DigitalLevelSelector";
+import BirthDateInput from "@/app/signup/_components/BirthDateInput";
+import LabeledInput from "@/app/signup/_components/LabeledInput";
+import { useAuthStore } from "@/stores/useAuth";
+import api from "@/apis/app";
+import { END_POINT } from "@/constants/route";
+import { AreaOption } from "@/app/signup/page";
+import { getAreaOptions, getInterestOptions } from "@/apis/options";
+import { useRouter } from "next/navigation";
+type AreaInfoType = {
+  area_id: number;
+  selectedSido: string;
+  selectedDistrict: string;
+};
+
+export default function EditProfilePage() {
+  const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const [areaOptions, setAreaOptions] = useState<AreaOption[]>([]);
+  const [interestOptions, setInterestOptions] = useState<
+    { id: number; interest_name: string }[]
+  >([]);
+  const [areaInfo, setAreaInfo] = useState({
+    area_id: -1,
+    selectedSido: "",
+    selectedDistrict: "",
+  });
+
+  const [form, setForm] = useState({
+    name: "",
+    nickname: "",
+    email: "",
+    phone: "",
+    birthYear: "",
+    birthMonth: "",
+    birthDay: "",
+    area_id: -1,
+    selectedSido: "",
+    selectedDistrict: "",
+    interests: [] as number[],
+    digital_level: null as number | null,
+  });
+  console.log("form", form);
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      await api.patch(
+        END_POINT.USERS_PROFILE,
+        {
+          name: form.name,
+          nickname: form.nickname,
+          phone_number: form.phone.replace(/-/g, ""),
+          date_of_birth: `${form.birthYear}-${form.birthMonth}-${form.birthDay}`,
+          area: form.area_id,
+          interests: form.interests,
+          digital_level: form.digital_level,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      alert("회원정보가 성공적으로 수정되었습니다.");
+      router.replace("/mypage");
+    } catch (error) {
+      console.error("회원정보 수정 실패:", error);
+      alert("회원정보 수정에 실패했습니다.");
+    }
+  };
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const res = await api.get(END_POINT.USERS_PROFILE, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const profile = res.data;
+
+      const [y, m, d] = profile.date_of_birth.split("-");
+      setForm((prev) => ({
+        ...prev,
+        name: profile.name,
+        nickname: profile.nickname,
+        email: profile.email,
+        phone: profile.phone_number,
+        birthYear: y,
+        birthMonth: m,
+        birthDay: d,
+        area: profile.area.id,
+        selectedSido: profile.area.full_path.split(" ")[0],
+        selectedDistrict: profile.area.full_path.split(" ")[1],
+        digital_level: profile.digital_level?.id ?? null,
+        interests: profile.interests.map((i: { id: number }) => i.id),
+      }));
+      setAreaInfo({
+        area_id: profile.area.id,
+        selectedSido: profile.area.full_path.split(" ")[0],
+        selectedDistrict: profile.area.full_path.split(" ")[1],
+      });
+    };
+
+    const fetchOptions = async () => {
+      const areaRes = await getAreaOptions();
+      const interestRes = await getInterestOptions();
+      setAreaOptions(areaRes);
+      setInterestOptions(interestRes.results);
+    };
+
+    fetchProfile();
+    fetchOptions();
+  }, [accessToken]);
+
+  const handleAreaInfoChange: React.Dispatch<
+    React.SetStateAction<AreaInfoType>
+  > = (infoOrUpdater) => {
+    // infoOrUpdater는 객체일 수도, 함수일 수도 있음
+    const newInfo =
+      typeof infoOrUpdater === "function"
+        ? infoOrUpdater(areaInfo)
+        : infoOrUpdater;
+
+    setAreaInfo(newInfo);
+    setForm((prev) => ({
+      ...prev,
+      area_id: newInfo.area_id,
+      selectedSido: newInfo.selectedSido,
+      selectedDistrict: newInfo.selectedDistrict,
+    }));
+  };
+
+  return (
+    <main className="w-full max-w-[1280px] px-16 py-12 mx-auto">
+      <h1 className="text-xl font-bold mb-10">회원정보 수정</h1>
+      <form
+        className="space-y-6 w-full max-w-md mx-auto"
+        onSubmit={handleSubmit}
+      >
+        <LabeledInput
+          label="이름"
+          name="name"
+          value={form.name}
+          onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+          required
+        />
+        <LabeledInput
+          label="닉네임"
+          name="nickname"
+          value={form.nickname}
+          onChange={(e) => setForm((p) => ({ ...p, nickname: e.target.value }))}
+          required
+        />
+        <LabeledInput
+          label="이메일"
+          name="email"
+          value={form.email}
+          onChange={() => {}}
+          readOnly
+          required
+        />
+        <LabeledInput
+          label="전화번호"
+          name="phone"
+          value={form.phone}
+          onChange={(e) => setForm((p) => ({ ...p, phone: e.target.value }))}
+          required
+        />
+        <BirthDateInput
+          birthYear={form.birthYear}
+          birthMonth={form.birthMonth}
+          birthDay={form.birthDay}
+          setSignupData={(updated: {
+            birthYear: string;
+            birthMonth: string;
+            birthDay: string;
+          }) => {
+            setForm((prev) => ({
+              ...prev,
+              birthYear: updated.birthYear,
+              birthMonth: updated.birthMonth,
+              birthDay: updated.birthDay,
+            }));
+          }}
+        />
+        <AreaSelector
+          areaOptions={areaOptions}
+          areaInfo={areaInfo}
+          setAreaInfo={handleAreaInfoChange}
+          onSelect={(sido, district, areaId) => {
+            if (areaId) {
+              setForm((prev) => ({
+                ...prev,
+                area_id: areaId,
+                selectedSido: sido,
+                selectedDistrict: district,
+              }));
+            }
+          }}
+        />
+
+        <InterestSelector
+          interests={interestOptions}
+          interest_ids={form.interests}
+          setInterestIds={(ids) =>
+            setForm((prev) => ({ ...prev, interests: ids }))
+          }
+        />
+        <DigitalLevelSelector
+          value={form.digital_level}
+          onChange={(val) =>
+            setForm((prev) => ({ ...prev, digital_level: val }))
+          }
+        />
+        <button
+          type="submit"
+          className="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 rounded mt-10"
+        >
+          수정 완료
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/signup/_components/BirthDateInput.tsx
+++ b/src/app/signup/_components/BirthDateInput.tsx
@@ -1,11 +1,19 @@
-import { SignupState } from "@/hooks/useSignupSubmit";
+// import { SignupState } from "@/hooks/useSignupSubmit";
 import TextInput from "../../../components/common/TextInput";
 
 interface Props {
+  // birthYear: string;
+  // birthMonth: string;
+  // birthDay: string;
+  // setSignupData: React.Dispatch<React.SetStateAction<SignupState>>;
   birthYear: string;
   birthMonth: string;
   birthDay: string;
-  setSignupData: React.Dispatch<React.SetStateAction<SignupState>>;
+  setSignupData: (updated: {
+    birthYear: string;
+    birthMonth: string;
+    birthDay: string;
+  }) => void;
 }
 
 export default function BirthDateInput({
@@ -22,7 +30,11 @@ export default function BirthDateInput({
           name="birthYear"
           value={birthYear}
           onChange={(e) =>
-            setSignupData((prev) => ({ ...prev, birthYear: e.target.value }))
+            setSignupData({
+              birthYear: e.target.value,
+              birthMonth: birthMonth,
+              birthDay: birthDay,
+            })
           }
           placeholder="YYYY"
           type="number"
@@ -33,7 +45,11 @@ export default function BirthDateInput({
           name="birthMonth"
           value={birthMonth}
           onChange={(e) =>
-            setSignupData((prev) => ({ ...prev, birthMonth: e.target.value }))
+            setSignupData({
+              birthYear: birthYear,
+              birthMonth: e.target.value,
+              birthDay: birthDay,
+            })
           }
           placeholder="MM"
           type="number"
@@ -44,7 +60,11 @@ export default function BirthDateInput({
           name="birthDay"
           value={birthDay}
           onChange={(e) =>
-            setSignupData((prev) => ({ ...prev, birthDay: e.target.value }))
+            setSignupData({
+              birthYear: birthYear,
+              birthMonth: birthMonth,
+              birthDay: e.target.value,
+            })
           }
           placeholder="DD"
           type="number"

--- a/src/app/signup/_components/InterestSelector.tsx
+++ b/src/app/signup/_components/InterestSelector.tsx
@@ -11,7 +11,7 @@ interface InterestSelectorProps {
 
 export default function InterestSelector({
   interests,
-  interest_ids,
+  interest_ids = [],
   setInterestIds,
 }: InterestSelectorProps) {
   const toggleInterest = (id: number) => {
@@ -33,7 +33,7 @@ export default function InterestSelector({
             type="checkbox"
             name="interest"
             className="accent-orange-600"
-            checked={interest_ids.includes(interest.id)}
+            checked={(interest_ids ?? []).includes(interest.id)}
             onChange={() => toggleInterest(interest.id)}
           />
           {interest.interest_name}

--- a/src/components/common/AreaSelector.tsx
+++ b/src/components/common/AreaSelector.tsx
@@ -88,8 +88,9 @@ export default function AreaSelector({
                     setAreaInfo((prev) => ({
                       ...prev,
                       selectedDistrict: district.area_name,
+                      area_id: district.id,
                     }));
-                    onSelect(selectedSido, district.area_name);
+                    onSelect(selectedSido, district.area_name, district.id);
                   }}
                   className="accent-orange-600 w-4 h-4"
                 />


### PR DESCRIPTION
## 변경 사항
<img width="739" alt="image" src="https://github.com/user-attachments/assets/349af7b9-c1f3-45c0-adf0-88c2497aeabf" />

- 마이페이지 > 회원정보 수정 페이지(EditProfilePage)를 새로 구현
- 유저 정보(이름, 닉네임, 생년월일, 연락처, 지역, 관심사, 디지털 수준)를 수정할 수 있도록 폼 구성
- GET /users/profile로 기존 정보 불러오고, PATCH /users/profile로 수정된 정보 서버에 반영
- 지역 선택은 AreaSelector, 관심사는 InterestSelector, 디지털 수준은 DigitalLevelSelector 공통 컴포넌트 재사용
- 생년월일은 BirthDateInput을 통해 연도/월/일 분리 입력
- 수정 완료 시 마이페이지(/mypage)로 리디렉션
- 수정 취소 버튼 구현

## 반영 브랜치
feature/#116-profile_edit_api -> develop

## 관련 이슈
close #116

## 참고 사항
추가로 공유하고 싶은 내용
